### PR TITLE
Initial commit / v 1.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+#
+# Exclude these files from release archives.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.github export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,11 @@
+<!--
+This repository is only for the WordPress PHPCompatibility ruleset, which prevents false positives from the PHPCompatibility standard by excluding back-fills and poly-fills which are included by WordPress.
+
+If your issue is related to the PHPCompatibility sniffs, please open an issue in the PHPCompatibility repository: https://github.com/PHPCompatibility/PHPCompatibility/issues
+
+Before opening a new issue, please search for duplicate issues to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
+
+If you are opening an issue to get a new back-fill / poly-fill which was added to WordPress excluded, please include links to the WordPress source code and the related Trac ticket to substantiate your request.
+
+Thanks!
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+sudo: false
+
+dist: trusty
+
+cache:
+  apt: true
+
+language: php
+
+## Cache composer downloads.
+cache:
+  directories:
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.2
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+    - php: 5.4
+
+before_install:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
+  - export XMLLINT_INDENT="    "
+  - composer install
+
+script:
+  - |
+    if [[ $TRAVIS_PHP_VERSION == "7.2" ]]; then
+      # Validate the xml file.
+      # @link http://xmlsoft.org/xmllint.html
+      xmllint --noout ./PHPCompatibilityWP/ruleset.xml
+
+      # Check the code-style consistency of the xml file.
+      diff -B ./PHPCompatibilityWP/ruleset.xml <(xmllint --format "./PHPCompatibilityWP/ruleset.xml")
+    fi
+
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - composer validate --no-check-all --with-dependencies --strict

--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCompatibilityWP">
+    <description>WordPress specific ruleset which checks for PHP cross version compatibility.</description>
+
+    <!--
+    The WordPress minimum PHP requirement is PHP 5.2.4.
+    Add the following in your project PHPCS ruleset to enforce this:
+    <config name="testVersion" value="5.2-"/>
+    
+    This directive is not included in this ruleset as individual projects may use
+    a different (higher) minimum PHP version.
+    -->
+
+    <rule ref="PHPCompatibility">
+        <!-- Contained in /wp-includes/compat.php. -->
+        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_hmacFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.json_encodeFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.json_decodeFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.json_pretty_printFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
+        <exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.is_iterableFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.is_countableFound"/>
+
+        <!-- Contained in /wp-includes/spl-autoload-compat.php. -->
+        <exclude name="PHPCompatibility.PHP.NewFunctions.spl_autoload_registerFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.spl_autoload_unregisterFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.spl_autoload_functionsFound"/>
+
+        <!-- Contained in /wp-includes/random_compat/random.php. -->
+        <exclude name="PHPCompatibility.PHP.NewConstants.php_version_idFound"/>
+
+        <!-- Contained in /wp-includes/random_compat/*.php (various files). -->
+        <exclude name="PHPCompatibility.PHP.NewFunctions.random_bytesFound"/>
+
+        <!-- Contained in /wp-includes/random_compat/random_int.php. -->
+        <exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>
+
+        <!-- Contained in /wp-includes/random_compat/error_polyfill.php. -->
+        <exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
+        <exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
+    </rule>
+
+    <!-- Whitelist the WP Core mysql_to_rfc3339() function. -->
+    <rule ref="PHPCompatibility.PHP.RemovedExtensions">
+        <properties>
+            <!-- Contained in /wp-includes/functions.php. -->
+            <property name="functionWhitelist" type="array" value="mysql_to_rfc3339"/>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,98 @@
+[![Latest Stable Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-wp/v/stable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-wp)
+[![Latest Unstable Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-wp/v/unstable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-wp)
+[![License](https://poser.pugx.org/PHPCompatibility/phpcompatibility-wp/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityWP/blob/master/LICENSE)
+[![Build Status](https://travis-ci.org/PHPCompatibility/PHPCompatibilityWP.png?branch=master)](https://travis-ci.org/PHPCompatibility/PHPCompatibilityWP)
+
 # PHPCompatibilityWP
-PHPCompatibility ruleset for WordPress projects
+
+Using the PHPCompatibilityWP standard, you can analyse the codebase of a WordPress-based project for PHP cross-version compatibility.
+
+
+## What's in this repo ?
+
+A PHPCompatibility ruleset for projects based on the WordPress CMS.
+
+This WordPress specific ruleset prevents false positives from the [PHPCompatibility standard](https://github.com/PHPCompatibility/PHPCompatibility) by excluding back-fills and poly-fills which are provided by WordPress.
+
+
+## Requirements
+
+* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+    * PHP 5.3+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.3.0+.
+    * PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 3.0.2+.
+
+    Use the latest stable release of PHP_CodeSniffer for the best results.
+    The minimum _recommended_ version of PHP_CodeSniffer is PHPCS 2.6.0.
+* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility).
+
+
+## Installation instructions
+
+### Installation instructions using Composer
+
+If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
+```bash
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3 phpcompatibility/phpcompatibility-wp:*
+composer install
+```
+
+If you already have a Composer PHPCS plugin installed, run:
+```bash
+composer require --dev phpcompatibility/phpcompatibility-wp:*
+composer install
+```
+
+Next, run:
+```bash
+vendor/bin/phpcs -i
+```
+If all went well, you will now see that the PHPCompatibility and PHPCompatibilityWP standards are installed for PHP_CodeSniffer.
+
+### Installation instructions without Composer (unsupported)
+
+* Install [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation).
+
+    PHP CodeSniffer offers a variety of installation methods to suit your work-flow: Composer, [PEAR](http://pear.php.net/PHP_CodeSniffer), a Phar file, zipped/tarred release archives or checking the repository out using Git.
+
+* Install [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) by [cloning the PHPCompatibility repository](https://github.com/PHPCompatibility/PHPCompatibility#installation-via-a-git-check-out-to-an-arbitrary-directory-method-2).
+
+* Install [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) by cloning this repository.
+
+* Add the paths to the directories in which you placed your copies of the PHPCompatibility repo and the PHPCompatibilityWP repo to the PHP CodeSniffer configuration using the below command from the command line:
+   ```bash
+   phpcs --config-set installed_paths /path/to/PHPCompatibility,/path/to/PHPCompatibilityWP
+   ```
+   For more information, see the PHP CodeSniffer wiki on the [`installed_paths` configuration variable](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
+
+* Verify that the PHPCompatibility standard is registered correctly by running `phpcs -i` on the command line. PHPCompatibility should be listed as one of the available standards.
+
+
+## How to use
+
+Now you can use the following command to inspect your code:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP
+
+# Or if you installed without using Composer:
+phpcs -p . --standard=PHPCompatibilityWP
+```
+
+By default, you will only receive notifications about deprecated and/or removed PHP features.
+
+To get the most out of the PHPCompatibilityWP standard, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
+
+The minimum PHP requirement of the WordPress project at this time is PHP 5.2.4. If you want to enforce this, either add `--runtime-set testVersion 5.2-` to your command-line command or add `<config name="testVersion" value="5.2-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset).
+
+For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
+
+
+## License
+
+All code within the PHPCompatibility organisation is released under the GNU Lesser General Public License (LGPL). For more information, visit https://www.gnu.org/copyleft/lesser.html
+
+
+## Changelog
+
+### 1.0.0 - 2018-07-17
+
+Initial release of the PHPCompatibilityWP ruleset.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+  "name" : "phpcompatibility/phpcompatibility-wp",
+  "description" : "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for WordPress projects.",
+  "type" : "phpcodesniffer-standard",
+  "keywords" : [ "compatibility", "phpcs", "standards", "wordpress" ],
+  "homepage" : "http://phpcompatibility.com/",
+  "license" : "LGPL-3.0-or-later",
+  "authors" : [ {
+    "name" : "Wim Godden",
+    "role" : "lead"
+  },
+  {
+    "name" : "Juliette Reinders Folmer",
+    "role" : "lead"
+  } ],
+  "support" : {
+    "issues" : "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+    "source" : "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+  },
+  "require" : {
+    "phpcompatibility/php-compatibility" : "*"
+  },
+  "suggest" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+    "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+  },
+  "prefer-stable" : true
+}


### PR DESCRIPTION
- Adds the WordPress specific PHPCompatibility ruleset.
- Adds README with basic installation and usage instructions.
- Adds `composer.json` file which requires the PHPCompatibility standard.
- Adds a Travis config to validate the ruleset XML and the Composer configuration on each update.
- Adds `.gitignore` to ignore the `vendor` directory and the `composer.lock` file.
- Adds `.gitattributes` to keep release archives clean.
- Adds `.github/issue_template.md` to try and prevent issues related to the generic PHPCompatibility standard from being opened in this repository.

FYI: The build won't pass until PR https://github.com/PHPCompatibility/PHPCompatibility/pull/689 has been merged and the package has been updated on Packagist.