### PR TITLE
Composer: Stabilize minimum PHPCompatibility version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ script:
 
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate
-  - composer validate --no-check-all --with-dependencies --strict
+  - composer validate --no-check-all --strict

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "source" : "https://github.com/PHPCompatibility/PHPCompatibilityWP"
   },
   "require" : {
-    "phpcompatibility/php-compatibility" : "*"
+    "phpcompatibility/php-compatibility" : "^8.1"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",


### PR DESCRIPTION
The WP ruleset references the following sniffs:
* PHPCompatibility.PHP.NewClasses - been in the repo from before the first tag
* PHPCompatibility.PHP.NewConstants - introduced in 8.1.0
* PHPCompatibility.PHP.NewFunctions - been in the repo from before the first tag
* PHPCompatibility.PHP.NewInterfaces`- introduced in 7.0.3
* PHPCompatibility.PHP.RemovedExtensions - been in the repo from before the first tag

In other words, the minimum version of PHPCompatibility should be 8.1.0 for this release.

This will also prevent an update to PHPCompatibility 9.0.0 before we've had a chance to update the ruleset to reflect the new sniff names.

In a separate commit, I've removed `--with-dependencies` from the Travis composer validation as the PHPCompatibility composer file ha a warning and would fail the build. The build should now pass.