### PR TITLE
Version 2.0.0 / Update for PHPCompatibility 9.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,8 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
-/.github export-ignore
+/.github/ export-ignore
+/Test/ export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -3,7 +3,7 @@ This repository is only for the WordPress PHPCompatibility ruleset, which preven
 
 If your issue is related to the PHPCompatibility sniffs, please open an issue in the PHPCompatibility repository: https://github.com/PHPCompatibility/PHPCompatibility/issues
 
-Before opening a new issue, please search for duplicate issues to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
+Before opening a new issue, please search for your issue to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
 
 If you are opening an issue to get a new back-fill / poly-fill which was added to WordPress excluded, please include links to the WordPress source code and the related Trac ticket to substantiate your request.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ language: php
 ## Cache composer downloads.
 cache:
   directories:
-    # Cache directory for older Composer versions.
-    - $HOME/.composer/cache/files
-    # Cache directory for more recent Composer versions.
     - $HOME/.cache/composer/files
 
 matrix:
@@ -30,6 +27,7 @@ before_install:
   - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
   - export XMLLINT_INDENT="    "
   - composer install
+  - vendor/bin/phpcs -i
 
 script:
   - |
@@ -41,6 +39,9 @@ script:
       # Check the code-style consistency of the xml file.
       diff -B ./PHPCompatibilityWP/ruleset.xml <(xmllint --format "./PHPCompatibilityWP/ruleset.xml")
     fi
+
+  # Test the ruleset.
+  - vendor/bin/phpcs ./Test/WPTest.php --standard=PHPCompatibilityWP --runtime-set testVersion 5.2
 
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -4,47 +4,37 @@
 
     <!--
     The WordPress minimum PHP requirement is PHP 5.2.4.
-    Add the following in your project PHPCS ruleset to enforce this:
+    Add the following in your project PHP_CodeSniffer ruleset to enforce this:
     <config name="testVersion" value="5.2-"/>
-    
+
     This directive is not included in this ruleset as individual projects may use
     a different (higher) minimum PHP version.
     -->
 
     <rule ref="PHPCompatibility">
         <!-- Contained in /wp-includes/compat.php. -->
-        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_hmacFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.json_encodeFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.json_decodeFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.json_pretty_printFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
-        <exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.is_iterableFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.is_countableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_hmacFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_encodeFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_decodeFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_equalsFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.json_pretty_printFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_last_error_msgFound"/>
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.jsonserializableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_replace_recursiveFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_countableFound"/>
 
         <!-- Contained in /wp-includes/spl-autoload-compat.php. -->
-        <exclude name="PHPCompatibility.PHP.NewFunctions.spl_autoload_registerFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.spl_autoload_unregisterFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.spl_autoload_functionsFound"/>
-
-        <!-- Contained in /wp-includes/random_compat/random.php. -->
-        <exclude name="PHPCompatibility.PHP.NewConstants.php_version_idFound"/>
-
-        <!-- Contained in /wp-includes/random_compat/*.php (various files). -->
-        <exclude name="PHPCompatibility.PHP.NewFunctions.random_bytesFound"/>
-
-        <!-- Contained in /wp-includes/random_compat/random_int.php. -->
-        <exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>
-
-        <!-- Contained in /wp-includes/random_compat/error_polyfill.php. -->
-        <exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
-        <exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_registerFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_unregisterFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_functionsFound"/>
     </rule>
 
+    <!-- Contained in /wp-includes/random_compat/ -->
+    <rule ref="PHPCompatibilityParagonieRandomCompat"/>
+
     <!-- Whitelist the WP Core mysql_to_rfc3339() function. -->
-    <rule ref="PHPCompatibility.PHP.RemovedExtensions">
+    <rule ref="PHPCompatibility.Extensions.RemovedExtensions">
         <properties>
             <!-- Contained in /wp-includes/functions.php. -->
             <property name="functionWhitelist" type="array" value="mysql_to_rfc3339"/>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-[![Latest Stable Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-wp/v/stable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-wp)
-[![Latest Unstable Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-wp/v/unstable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-wp)
-[![License](https://poser.pugx.org/PHPCompatibility/phpcompatibility-wp/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityWP/blob/master/LICENSE)
+[![Latest Stable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-wp/v/stable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-wp)
+[![Latest Unstable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-wp/v/unstable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-wp)
+[![License](https://poser.pugx.org/phpcompatibility/phpcompatibility-wp/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityWP/blob/master/LICENSE)
 [![Build Status](https://travis-ci.org/PHPCompatibility/PHPCompatibilityWP.svg?branch=master)](https://travis-ci.org/PHPCompatibility/PHPCompatibilityWP)
 
 # PHPCompatibilityWP
 
-Using the PHPCompatibilityWP standard, you can analyse the codebase of a WordPress-based project for PHP cross-version compatibility.
+Using PHPCompatibilityWP, you can analyse the codebase of a WordPress-based project for PHP cross-version compatibility.
 
 
 ## What's in this repo ?
 
-A PHPCompatibility ruleset for projects based on the WordPress CMS.
+A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects based on the WordPress CMS.
 
 This WordPress specific ruleset prevents false positives from the [PHPCompatibility standard](https://github.com/PHPCompatibility/PHPCompatibility) by excluding back-fills and poly-fills which are provided by WordPress.
 
@@ -22,13 +22,14 @@ This WordPress specific ruleset prevents false positives from the [PHPCompatibil
     * PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 3.0.2+.
 
     Use the latest stable release of PHP_CodeSniffer for the best results.
-    The minimum _recommended_ version of PHP_CodeSniffer is PHPCS 2.6.0.
-* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility).
+    The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.
+* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) 9.0.0+.
+* [PHPCompatibilityParagonie](https://github.com/PHPCompatibility/PHPCompatibilityParagonie) 1.0.0+.
 
 
 ## Installation instructions
 
-### Installation instructions using Composer
+The only supported installation method is via [Composer](https://getcomposer.org/).
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
@@ -36,7 +37,7 @@ composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3 php
 composer install
 ```
 
-If you already have a Composer PHPCS plugin installed, run:
+If you already have a Composer PHP_CodeSniffer plugin installed, run:
 ```bash
 composer require --dev phpcompatibility/phpcompatibility-wp:*
 composer install
@@ -46,25 +47,7 @@ Next, run:
 ```bash
 vendor/bin/phpcs -i
 ```
-If all went well, you will now see that the PHPCompatibility and PHPCompatibilityWP standards are installed for PHP_CodeSniffer.
-
-### Installation instructions without Composer (unsupported)
-
-* Install [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation).
-
-    PHP CodeSniffer offers a variety of installation methods to suit your work-flow: Composer, [PEAR](http://pear.php.net/PHP_CodeSniffer), a Phar file, zipped/tarred release archives or checking the repository out using Git.
-
-* Install [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) by [cloning the PHPCompatibility repository](https://github.com/PHPCompatibility/PHPCompatibility#installation-via-a-git-check-out-to-an-arbitrary-directory-method-2).
-
-* Install [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) by cloning this repository.
-
-* Add the paths to the directories in which you placed your copies of the PHPCompatibility repo and the PHPCompatibilityWP repo to the PHP CodeSniffer configuration using the below command from the command line:
-   ```bash
-   phpcs --config-set installed_paths /path/to/PHPCompatibility,/path/to/PHPCompatibilityWP
-   ```
-   For more information, see the PHP CodeSniffer wiki on the [`installed_paths` configuration variable](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
-
-* Verify that the PHPCompatibility standard is registered correctly by running `phpcs -i` on the command line. PHPCompatibility should be listed as one of the available standards.
+If all went well, you will now see that the `PHPCompatibility`, `PHPCompatibilityWP` and some more PHPCompatibility standards are installed for PHP_CodeSniffer.
 
 
 ## How to use
@@ -72,9 +55,6 @@ If all went well, you will now see that the PHPCompatibility and PHPCompatibilit
 Now you can use the following command to inspect your code:
 ```bash
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP
-
-# Or if you installed without using Composer:
-phpcs -p . --standard=PHPCompatibilityWP
 ```
 
 By default, you will only receive notifications about deprecated and/or removed PHP features.
@@ -83,8 +63,21 @@ To get the most out of the PHPCompatibilityWP standard, you should specify a `te
 
 The minimum PHP requirement of the WordPress project at this time is PHP 5.2.4. If you want to enforce this, either add `--runtime-set testVersion 5.2-` to your command-line command or add `<config name="testVersion" value="5.2-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset).
 
+For example:
+```bash
+# For a project which should be compatible with PHP 5.2 and higher:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP --runtime-set testVersion 5.2-
+```
+
 For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
 
+
+### Testing PHP files only
+
+By default PHP_CodeSniffer will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.2-
+```
 
 ## License
 
@@ -92,6 +85,13 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 
 
 ## Changelog
+
+### 2.0.0 - 2018-10-07
+
+- Ruleset: Updated for compatibility with PHPCompatibility 9.0+.
+- Composer: Added dependency for a dedicated polyfill-based PHPCompatibility ruleset.
+- CI: Added a test for the ruleset.
+- Readme: Removed the installation instructions for a non-Composer based install.
 
 ### 1.0.0 - 2018-07-17
 

--- a/Test/WPTest.php
+++ b/Test/WPTest.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ *
+ * This file should only test the polyfills provided by WordPress itself.
+ * The polyfills provided via dependencies will be tested via the repo containing
+ * the dedicated ruleset(s) for those dependencies.
+ */
+$a = hash_hmac();
+$a = json_encode();
+$a = json_decode();
+$a = hash_equals();
+
+echo JSON_PRETTY_PRINT;
+$a = json_last_error_msg();
+class ABC implements JsonSerializable {}
+
+$a = array_replace_recursive();
+$a = is_iterable();
+$a = is_countable();
+
+$a = spl_autoload_register();
+$a = spl_autoload_unregister();
+$a = spl_autoload_functions();
+
+$a = mysql_to_rfc3339();

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name" : "phpcompatibility/phpcompatibility-wp",
-  "description" : "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for WordPress projects.",
+  "description" : "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
   "type" : "phpcodesniffer-standard",
   "keywords" : [ "compatibility", "phpcs", "standards", "wordpress" ],
   "homepage" : "http://phpcompatibility.com/",
@@ -18,10 +18,14 @@
     "source" : "https://github.com/PHPCompatibility/PHPCompatibilityWP"
   },
   "require" : {
-    "phpcompatibility/php-compatibility" : "^8.1"
+    "phpcompatibility/php-compatibility" : "^9.0",
+    "phpcompatibility/phpcompatibility-paragonie" : "^1.0"
+  },
+  "require-dev" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true


### PR DESCRIPTION
:warning: **IMPORTANT** :warning:
The build for this PR will not pass until PHPCompatibility 9.0.0 and the polyfill rulesets has been released.  This PR should not be merged until then. 

---

This update accounts for the following changes:
* Ruleset:
    - Updated sniff error codes for compatibility with PHPCompatibility 9.0.0.
    - Defer to the dedicated polyfill rulesets for polyfills provided by project dependencies.
* Composer:
    - Require relevant dedicated polyfill ruleset.
    - Require `dev` the DealerDirect PHPCS Composer plugin to sort out the `installed_paths` so Travis can test the ruleset.
    - Improved the project description.
* Travis/Tests:
    - Added testing of the ruleset.
* Issue template: minor textual tweak.
* Readme:
    - Added information about the dependency on the polyfill ruleset.
    - Removed non-Composer installation instructions.
        As there are now more dependencies for this project, installation without using Composer, while of course still possible, is no longer _supported_.
    - Added section about only testing PHP files.
    - Added changelog for version 2.0.0.

Additionally, in all user-facing texts, the abbreviation `PHPCS` has been expanded to read `PHP_CodeSniffer`.

----

Additional notes:
* The changes in [PHPCompatibility 9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/pull/741) warrant for this release to be a major release again.
    To that end, I've re-milestoned the PRs which had been merged so far to the `2.0.0` milestone.