### PR TITLE
Allow for Sodium_Compat

### DIFF
--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -31,8 +31,13 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_functionsFound"/>
     </rule>
 
-    <!-- Contained in /wp-includes/random_compat/ -->
-    <rule ref="PHPCompatibilityParagonieRandomCompat"/>
+    <!--
+    The ParagonieSodiumCompat ruleset includes the ParagonieRandomCompat ruleset.
+
+    RancomCompat is contained in /wp-includes/random_compat/ since WP 4.4.0
+    SodiumCompat is contained in /wp-includes/sodium_compat/ since WP 5.2.0
+    -->
+    <rule ref="PHPCompatibilityParagonieSodiumCompat"/>
 
     <!-- Whitelist the WP Core mysql_to_rfc3339() function. -->
     <rule ref="PHPCompatibility.Extensions.RemovedExtensions">


### PR DESCRIPTION
WordPress 5.2 (released May 7 2019) includes the Paragonie Sodium Compat library.