### PR TITLE
Update minimum supported PHP version

### DIFF
--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -4,7 +4,7 @@
 
     <!--
     The WordPress minimum PHP requirement was 5.2.4 up to WP 5.1.
-    As of WP 5.2, the new minimum PHP requirement is PHP 5.6.
+    As of WP 5.2, the new minimum PHP requirement is PHP 5.6.20.
     Add the following in your project PHP_CodeSniffer ruleset to enforce this:
     <config name="testVersion" value="5.6-"/>
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By default, you will only receive notifications about deprecated and/or removed 
 
 To get the most out of the PHPCompatibilityWP standard, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
 
-The minimum PHP requirement of the WordPress project up to WP 5.1 was 5.2.4. As of WP 5.2 it will be PHP 5.6. If you want to enforce this, either add `--runtime-set testVersion 5.6-` to your command-line command or add `<config name="testVersion" value="5.6-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset).
+The minimum PHP requirement of the WordPress project up to WP 5.1 was 5.2.4. As of WP 5.2 it will be PHP 5.6.20. If you want to enforce this, either add `--runtime-set testVersion 5.6-` to your command-line command or add `<config name="testVersion" value="5.6-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset).
 
 For example:
 ```bash


### PR DESCRIPTION
Precision: The minimum PHP requirement as of WP 5.2 is PHP 5.6.20.