### PR TITLE
Update version of Composer PHPCS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The only supported installation method is via [Composer](https://getcomposer.org
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.6 phpcompatibility/phpcompatibility-wp:*
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^0.7" phpcompatibility/phpcompatibility-wp:*
 composer install
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     "phpcompatibility/phpcompatibility-paragonie" : "^1.0"
   },
   "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.6"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true


### PR DESCRIPTION
The DealerDirect Composer plugin has released version `0.7.0` a few months ago, which is compatible with Composer 2.x.
As Composer 2.0 has just been released, we should make sure not to recommend installing an older version of the plugin than `0.7.0`.

We also need to make sure we use the right version of the plugin ourselves in the `require-dev`.

As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats ^0.3 as >=0.3.0 <0.4.0.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-