### PR TITLE
add quotes around version for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ The only supported installation method is via [Composer](https://getcomposer.org
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^0.7" phpcompatibility/phpcompatibility-wp:*
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^0.7" phpcompatibility/phpcompatibility-wp:"*"
 composer install
 ```
 
 If you already have a Composer PHP_CodeSniffer plugin installed, run:
 ```bash
-composer require --dev phpcompatibility/phpcompatibility-wp:*
+composer require --dev phpcompatibility/phpcompatibility-wp:"*"
 composer install
 ```
 


### PR DESCRIPTION
I found that copying the current command errored reporting the version was not found. Changing `*` to `"*"` fixed this.