### PR TITLE
Account for two new constant polyfills as added in WP 5.8

### DIFF
--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -26,6 +26,7 @@
         * array_replace_recursive(): since WP 4.5.3 up to 5.2.x. The polyfill was removed in WP 5.3.
         * is_iterable(): since WP 4.9.6
         * is_countable(): since WP 4.9.6
+        * IMAGETYPE_WEBP and IMG_WEBP: since WP 5.8.0.
         -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_hmacFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_encodeFound"/>
@@ -37,6 +38,8 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_replace_recursiveFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_countableFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.imagetype_webpFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.img_webpFound"/>
 
         <!--
         Contained in /wp-includes/spl-autoload-compat.php.

--- a/Test/WPTest.php
+++ b/Test/WPTest.php
@@ -24,3 +24,5 @@ $a = spl_autoload_unregister();
 $a = spl_autoload_functions();
 
 $a = mysql_to_rfc3339();
+
+echo IMAGETYPE_WEBP, IMG_WEBP;


### PR DESCRIPTION
Refs:
* https://core.trac.wordpress.org/changeset/50810#file7
* https://core.trac.wordpress.org/browser/trunk/src/wp-includes/compat.php#L374-L380