### PR TITLE
GH Actions: always use --no-interaction for Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ matrix.phpcompat != 'stable' }}
         run: |
           composer config minimum-stability dev
-          composer require --no-update phpcompatibility/php-compatibility:"${{ matrix.phpcompat }}"
+          composer require --no-update phpcompatibility/php-compatibility:"${{ matrix.phpcompat }}" --no-interaction
 
       - name: Install dependencies
         run: composer install --no-interaction --no-progress


### PR DESCRIPTION
Adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.