### PR TITLE
WP 5.9: account for new function polyfills

### DIFF
--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -27,6 +27,11 @@
         * is_iterable(): since WP 4.9.6
         * is_countable(): since WP 4.9.6
         * IMAGETYPE_WEBP and IMG_WEBP: since WP 5.8.0.
+        * array_key_first(): since WP 5.9.0
+        * array_key_last(): since WP 5.9.0
+        * str_contains(): since WP 5.9.0
+        * str_starts_with(): since WP 5.9.0
+        * str_ends_with(): since WP 5.9.0
         -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_hmacFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_encodeFound"/>
@@ -40,6 +45,11 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_countableFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.imagetype_webpFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.img_webpFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_firstFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_containsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
 
         <!--
         Contained in /wp-includes/spl-autoload-compat.php.

--- a/Test/WPTest.php
+++ b/Test/WPTest.php
@@ -25,4 +25,11 @@ $a = spl_autoload_functions();
 
 $a = mysql_to_rfc3339();
 
+if (array_key_first($array)
+    || array_key_last($array)) {}
+
+$a = str_contains($haystack, $needle);
+$a = str_starts_with( $haystack, $needle );
+$a = str_ends_with( $haystack, $needle );
+
 echo IMAGETYPE_WEBP, IMG_WEBP;


### PR DESCRIPTION
WP 5.9 contains polyfills for five new PHP native functions:
* `array_key_first()` and `array_key_last()`, which were both introduced in PHP 7.3.
* `str_contains()`, `str_starts_with()` and `str_ends_with()`, which were introduced in PHP 8.0.

While the PHP 8.0 functions are not yet flagged by the latest release of PHPCompatibility, they will be once PHPCompatibility 10.0 comes out.

As `exclude`-ing error codes which don't exist yet does not lead to errors in PHPCS, we may as well add the exclusions for all WP 5.9 polyfills in one go.

Refs:
* https://core.trac.wordpress.org/changeset/52038
* https://core.trac.wordpress.org/changeset/52039
* https://core.trac.wordpress.org/changeset/52040
* https://core.trac.wordpress.org/browser/trunk/src/wp-includes/compat.php#L398-L479