### PR TITLE
GH Actions/basics: revert to xmllint-problem-matcher v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Show violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1.1
+      - uses: korelstar/xmllint-problem-matcher@v1
 
       # Validate the xml file.
       # @link http://xmlsoft.org/xmllint.html


### PR DESCRIPTION
As the `korelstar/xmllint-problem-matcher` repo now has a long-running `v1` branch, this update which was included in PR #42 is no longer needed (and would necessitate more frequent updates if it would remain).

Ref:
* korelstar/xmllint-problem-matcher#7