### PR TITLE
WP 6.5: account for new function polyfills

### DIFF
--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -33,6 +33,7 @@
         * str_contains(): since WP 5.9.0
         * str_starts_with(): since WP 5.9.0
         * str_ends_with(): since WP 5.9.0
+        * array_is_list(): since WP 6.5.0
         -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_hmacFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_encodeFound"/>
@@ -51,6 +52,7 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_containsFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>
 
         <!--
         Contained in /wp-includes/spl-autoload-compat.php.

--- a/Test/WPTest.php
+++ b/Test/WPTest.php
@@ -33,3 +33,5 @@ $a = str_starts_with( $haystack, $needle );
 $a = str_ends_with( $haystack, $needle );
 
 echo IMAGETYPE_WEBP, IMG_WEBP;
+
+if (array_is_list($array)) {}


### PR DESCRIPTION
WP 6.5 contains a polyfill for `array_is_list`, which was introduced in PHP 8.1.

Ticket: https://core.trac.wordpress.org/ticket/55105
Commit: https://core.trac.wordpress.org/changeset/57337