### PR TITLE
Version 3.0.0-alpha1 / Update for PHPCompatibility 10.0.0-alpha1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
         include:
           - php: '7.4'
-            phpcompat: 'dev-develop as 9.99.99'
+            phpcompat: 'dev-develop as 10.99.99'
             experimental: true
 
     name: "Test: PHP ${{ matrix.php }} - PHPCompat ${{ matrix.phpcompat }}"
@@ -102,4 +102,7 @@ jobs:
 
       # Make sure that known polyfills don't trigger any errors.
       - name: Test the ruleset
-        run: vendor/bin/phpcs -ps ./Test/WPTest.php --standard=PHPCompatibilityWP --runtime-set testVersion 5.2-
+        run: >
+          vendor/bin/phpcs -ps ./Test/WPTest.php --standard=PHPCompatibilityWP
+          --exclude=PHPCompatibility.Upgrade.LowPHP
+          --runtime-set testVersion 5.2-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PHPCompatibilityWP
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/phpcompatibility/phpcompatibility-wp?label=stable)](https://packagist.org/packages/phpcompatibility/phpcompatibility-wp)
-[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/phpcompatibility/phpcompatibility-wp)
+[![Latest Stable Version](https://img.shields.io/packagist/v/phpcompatibility/phpcompatibility-wp?label=stable)][packagist]
+[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)][packagist]
 [![License](https://img.shields.io/github/license/PHPCompatibility/PHPCompatibilityWP?color=00a7a7)](https://github.com/PHPCompatibility/PHPCompatibilityWP/blob/master/LICENSE)
 [![Build Status](https://github.com/PHPCompatibility/PHPCompatibilityWP/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/PHPCompatibility/PHPCompatibilityWP/actions/workflows/ci.yml)
 
@@ -15,29 +15,34 @@ A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issue
 This WordPress specific ruleset prevents false positives from the [PHPCompatibility standard](https://github.com/PHPCompatibility/PHPCompatibility) by excluding back-fills and poly-fills which are provided by WordPress.
 
 
+## Funding
+
+**This project needs funding.**
+
+The project team has spend thousands of hours creating and maintaining the PHPCompatibility packages. This is unsustainable without funding.
+
+If you use PHPCompatibility, please fund this work by setting up a monthly contribution to the [PHP_CodeSniffer Open Collective].
+
+
 ## Requirements
 
-* [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
-    - PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) 3.3.0+.
-
+* PHP > 5.4
+* [PHP_CodeSniffer] >= 3.13.3.
     Use the latest stable release of PHP_CodeSniffer for the best results.
-* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) 9.0.0+.
-* [PHPCompatibilityParagonie](https://github.com/PHPCompatibility/PHPCompatibilityParagonie) 1.0.0+.
+* [PHPCompatibility] 10.0.0+.
+* [PHPCompatibilityParagonie] 2.0.0+.
 
 
 ## Installation instructions
 
-The only supported installation method is via [Composer](https://getcomposer.org/).
+The only supported installation method is via [Composer].
 
-If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
+[Composer] will automatically install the project dependencies and register the external rulesets with PHP_CodeSniffer using the [Composer PHPCS plugin].
+
+Run the following from the root of your project:
 ```bash
 composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^1.0" phpcompatibility/phpcompatibility-wp:"*"
-```
-
-If you already have a Composer PHP_CodeSniffer plugin installed, run:
-```bash
-composer require --dev phpcompatibility/phpcompatibility-wp:"*"
+composer require --dev phpcompatibility/phpcompatibility-wp:"^3.0@dev"
 ```
 
 Next, run:
@@ -47,35 +52,61 @@ vendor/bin/phpcs -i
 If all went well, you will now see that the `PHPCompatibility`, `PHPCompatibilityWP` and some more PHPCompatibility standards are installed for PHP_CodeSniffer.
 
 
+## Upgrade instructions
+
+To upgrade this package, run the following command:
+```bash
+composer update --dev phpcompatibility/phpcompatibility-wp --with-dependencies
+```
+
+> [!TIP]
+> If you have a _root_ requirement in your project for one of the packages used by this project, you may need to update with `--with-all-dependencies` instead.
+
+
 ## How to use
 
-Now you can use the following command to inspect your code:
+You can now use the following command to inspect your code:
 ```bash
-./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP
+vendor/bin/phpcs -p . --standard=PHPCompatibilityWP
 ```
 
 By default, you will only receive notifications about deprecated and/or removed PHP features.
 
 To get the most out of the PHPCompatibilityWP standard, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
 
-The minimum PHP requirement of the WordPress project up to WP 5.1 was 5.2.4. As of WP 5.2 it will be PHP 5.6.20. If you want to enforce this, either add `--runtime-set testVersion 5.6-` to your command-line command or add `<config name="testVersion" value="5.6-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset).
+The WordPress minimum PHP requirement was 5.2.4 up to WP 5.1.
+* As of WP 5.2, the new minimum PHP requirement is PHP 5.6.20.
+* As of WP 6.3, the new minimum PHP requirement is PHP 7.0.0.
+* As of WP 6.6, the new minimum PHP requirement is PHP 7.2.24.
+
+To enforce for PHPCompatibility to run against the PHP version you want to support, add `--runtime-set testVersion 7.2-` to your command-line command or add `<config name="testVersion" value="7.2-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset), replacing `7.2-` with a `testVersion` of your choice.
 
 For example:
 ```bash
 # For a project which should be compatible with PHP 5.6 and higher:
-./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP --runtime-set testVersion 5.6-
+vendor/bin/phpcs -p . --standard=PHPCompatibilityWP --runtime-set testVersion 5.6-
 ```
 
-For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
+For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility][PHPCompatibility-testVersion] standard.
 
 
 ### Testing PHP files only
 
-By default PHP_CodeSniffer will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
+By default PHP_CodeSniffer < 4.0 will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
 ```bash
-./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.6-
+vendor/bin/phpcs -p . --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.6-
 ```
 
 ## License
 
 All code within the PHPCompatibility organisation is released under the GNU Lesser General Public License (LGPL). For more information, visit <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+
+[packagist]:                       https://packagist.org/packages/phpcompatibility/phpcompatibility-wp
+[Composer]:                        https://getcomposer.org/
+[Composer PHPCS plugin]:           https://github.com/PHPCSStandards/composer-installer/
+[PHP_CodeSniffer]:                 https://github.com/PHPCSStandards/PHP_CodeSniffer
+[PHP_CodeSniffer Open Collective]: https://opencollective.com/php_codesniffer
+[PHPCompatibility]:                https://github.com/PHPCompatibility/PHPCompatibility
+[PHPCompatibility-testVersion]:    https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
+[PHPCompatibilityParagonie]:       https://github.com/PHPCompatibility/PHPCompatibilityParagonie

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,8 @@
     "lock": false
   },
   "require" : {
-    "squizlabs/php_codesniffer" : "^3.3",
-    "phpcompatibility/php-compatibility" : "^9.0",
-    "phpcompatibility/phpcompatibility-paragonie" : "^1.0"
-  },
-  "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
-  },
-  "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
-    "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+    "phpcompatibility/php-compatibility" : "^10.0@dev",
+    "phpcompatibility/phpcompatibility-paragonie" : "^2.0@dev"
   },
   "prefer-stable" : true
 }


### PR DESCRIPTION
This update accounts for the following changes:
* Ruleset:
    _No ruleset updates needed (at this time)._
* Composer:
    - Update the version for the PHPCompatibility dependency. The `@dev` version number suffix should ensure that the PHPCompatibility 10.0.0-alpha1 version can be installed, even if the project minimum stability does not specifically allow for dev versions.
    - Remove the DealerDirect Composer PHPCS plugin dependency. This plugin will now automatically be installed as it is a dependency of PHPCSUtils and therefore of PHPCompatibility itself. Not having it set as an explicit dependency here, will prevent potential future conflicts with the supported versions of the plugin.
    - Removed the `suggest` section. The DealerDirect plugin no longer needs to be suggested and after two years, people should have gotten the message about using the `roave/security-advisories`.
* Readme:
    - Updated the minimum PHP and PHPCS requirements.
    - Updated the installation instructions for the 3.0.0-alpha1 release (being a dev release).
    - Updated the installation instructions to no longer mention adding a Composer plugin to sort out the PHPCS `installed_paths`.
    - Added upgrade instructions.
    - Added section about funding.
    - Use link list for links used multiple times.
    - Minor other tweaks after critical read-through of the README.
* CI:
    - Continue testing against `dev-develop`.
    - Prevent builds failing on low PHP versions on the recommendation to use a more recent PHP version.