### PR TITLE
GH Actions: split workflow

### DIFF
--- a/.github/workflows/ci-cron.yml
+++ b/.github/workflows/ci-cron.yml
@@ -1,0 +1,15 @@
+name: CI Cronjob
+
+on:
+  # Run this workflow on day 15 of every month as the repo isn't that active.
+  schedule:
+    - cron: '0 0 15 * *'
+
+permissions: {}
+
+jobs:
+  QA:
+    # Don't run the cron job on forks.
+    if: ${{ github.event.repository.fork == false }}
+
+    uses: ./.github/workflows/reusable-qa-checks.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,103 +6,11 @@ on:
     branches:
       - master
   pull_request:
-  # Also run this workflow on day 15 of every month as the repo isn't that active.
-  schedule:
-    - cron: '0 0 15 * *'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
-  xmllint:
-    # Don't run the cron job on forks.
-    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
-
-    name: 'Check XML'
-    runs-on: ubuntu-latest
-
-    env:
-      XMLLINT_INDENT: '    '
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
-        with:
-          php-version: 'latest'
-          coverage: none
-
-      # Install dependencies to make sure the PHPCS XSD file is available.
-      - name: Install dependencies
-        run: composer install --no-dev --no-interaction --no-progress
-
-      - name: Validate Ruleset XML file against schema
-        uses: phpcsstandards/xmllint-validate@0fd9c4a9046055f621fca4bbdccb8eab1fd59fdc # v1.0.1
-        with:
-          pattern: "./*/ruleset.xml"
-          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
-
-      # Check the code-style consistency of the xml file.
-      # Note: this needs xmllint, but that will be installed via the phpcsstandards/xmllint-validate action runner.
-      - name: Check code style
-        run: diff -B ./PHPCompatibilityWP/ruleset.xml <(xmllint --format "./PHPCompatibilityWP/ruleset.xml")
-
-  test:
-    # Don't run the cron job on forks.
-    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
-
-    needs: xmllint
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php: ['5.4', 'latest']
-        phpcompat: ['stable']
-        experimental: [false]
-
-        include:
-          - php: '7.4'
-            phpcompat: 'dev-develop as 10.99.99'
-            experimental: true
-
-    name: "Test: PHP ${{ matrix.php }} - PHPCompat ${{ matrix.phpcompat }}"
-    continue-on-error: ${{ matrix.experimental }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
-        with:
-          php-version: ${{ matrix.php }}
-          ini-values: error_reporting=E_ALL, display_errors=On, display_startup_errors=On
-          coverage: none
-
-      - name: Conditionally update PHPCompatibility to develop version
-        if: ${{ matrix.phpcompat != 'stable' }}
-        run: |
-          composer config minimum-stability dev
-          composer require --no-update phpcompatibility/php-compatibility:"${{ matrix.phpcompat }}" --no-interaction
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress
-
-      # Validate the composer.json file.
-      # @link https://getcomposer.org/doc/03-cli.md#validate
-      - name: Validate Composer installation
-        run: composer validate --no-check-all --strict
-
-      # Make sure that known polyfills don't trigger any errors.
-      - name: Test the ruleset
-        run: >
-          vendor/bin/phpcs -ps ./Test/WPTest.php --standard=PHPCompatibilityWP
-          --exclude=PHPCompatibility.Upgrade.LowPHP
-          --runtime-set testVersion 5.2-
+  QA:
+    uses: ./.github/workflows/reusable-qa-checks.yml

--- a/.github/workflows/reusable-qa-checks.yml
+++ b/.github/workflows/reusable-qa-checks.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  xmllint:
+    name: 'Check XML'
+    runs-on: ubuntu-latest
+
+    env:
+      XMLLINT_INDENT: '    '
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
+        with:
+          php-version: 'latest'
+          coverage: none
+
+      # Install dependencies to make sure the PHPCS XSD file is available.
+      - name: Install dependencies
+        run: composer install --no-dev --no-interaction --no-progress
+
+      - name: Validate Ruleset XML file against schema
+        uses: phpcsstandards/xmllint-validate@0fd9c4a9046055f621fca4bbdccb8eab1fd59fdc # v1.0.1
+        with:
+          pattern: "./*/ruleset.xml"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
+
+      # Check the code-style consistency of the xml file.
+      # Note: this needs xmllint, but that will be installed via the phpcsstandards/xmllint-validate action runner.
+      - name: Check code style
+        run: diff -B ./PHPCompatibilityWP/ruleset.xml <(xmllint --format "./PHPCompatibilityWP/ruleset.xml")
+
+  test:
+    needs: xmllint
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['5.4', 'latest']
+        phpcompat: ['stable']
+        experimental: [false]
+
+        include:
+          - php: '7.4'
+            phpcompat: 'dev-develop as 10.99.99'
+            experimental: true
+
+    name: "Test: PHP ${{ matrix.php }} - PHPCompat ${{ matrix.phpcompat }}"
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: error_reporting=E_ALL, display_errors=On, display_startup_errors=On
+          coverage: none
+
+      - name: Conditionally update PHPCompatibility to develop version
+        if: ${{ matrix.phpcompat != 'stable' }}
+        run: |
+          composer config minimum-stability dev
+          composer require --no-update phpcompatibility/php-compatibility:"${{ matrix.phpcompat }}" --no-interaction
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+
+      # Validate the composer.json file.
+      # @link https://getcomposer.org/doc/03-cli.md#validate
+      - name: Validate Composer installation
+        run: composer validate --no-check-all --strict
+
+      # Make sure that known polyfills don't trigger any errors.
+      - name: Test the ruleset
+        run: >
+          vendor/bin/phpcs -ps ./Test/WPTest.php --standard=PHPCompatibilityWP
+          --exclude=PHPCompatibility.Upgrade.LowPHP
+          --runtime-set testVersion 5.2-


### PR DESCRIPTION
GitHub has the annoying habit of disabling workflows with a cron job after two months if the repo doesn't see any activity.

This is regularly the case for this repo and this creates the following problem:
* If the same workflow is used for both the cron job as well as the push/pull_request CI checks...
* ... and a repo doesn't have any activity in two months time...
* ... the workflow gets disabled...
* ... which then also means that CI checks will no longer be run for new PRs....
* ... which means new PRs can't be merged as (in most cases) the repo has branch protection in place and requires that the CI checks pass before a PR can be merged.

This commit basically changes the original workflow to a reusable workflow and then creates two new workflows, with different `on` targets, which each trigger the reusable workflow.
* One workflow will be triggered via `cron`.
* One workflow will have all the other triggers (`push`/`pull_request`/`workflow_dispatch`).

This way, if the cron job workflow gets disabled, the workflow which is used for the other triggers will continue to function.

The downside of this, is that it may go unnoticed that the cron job has stopped running, but so be it.