### PR TITLE
WP 6.5/6.8/6.9: account for new function and constant polyfills

### DIFF
--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -36,6 +36,14 @@
         * str_starts_with(): since WP 5.9.0
         * str_ends_with(): since WP 5.9.0
         * array_is_list(): since WP 6.5.0
+        * IMAGETYPE_AVIF and IMG_AVIF: since WP 6.5.0
+        * array_find(): since WP 6.8.0
+        * array_find_key(): since WP 6.8.0
+        * array_any(): since WP 6.8.0
+        * array_all(): since WP 6.8.0
+        * array_first(): since WP 6.9.0
+        * array_last(): since WP 6.9.0
+        * IMAGETYPE_HEIF: since WP 6.9.0
         -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_hmacFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_encodeFound"/>
@@ -55,6 +63,15 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.imagetype_avifFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.img_avifFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_findFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_find_keyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_anyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_allFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_firstFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_lastFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.imagetype_heifFound"/>
 
         <!--
         Contained in /wp-includes/spl-autoload-compat.php.

--- a/Test/WPTest.php
+++ b/Test/WPTest.php
@@ -35,3 +35,15 @@ $a = str_ends_with( $haystack, $needle );
 echo IMAGETYPE_WEBP, IMG_WEBP;
 
 if (array_is_list($array)) {}
+
+echo IMAGETYPE_AVIF, IMG_AVIF;
+
+$first_match = array_find( $array, $callback );
+$first_match_key = array_find_key( $array, $callback );
+if ( array_any( $array, $callback ) ) {}
+if ( array_all( $array, $callback ) ) {}
+
+$first_element = array_first( $array );
+$last_element = array_last( $array );
+
+echo IMAGETYPE_HEIF;


### PR DESCRIPTION
I checked the WordPress `src/wp-includes/compat.php` file for new polyfills that should be added, and here is what I found that was missing in this repository:

WP 6.5 added polyfills for:
  * `IMAGETYPE_AVIF` and `IMG_AVIF` constants, which were introduced in PHP 8.1. See https://core.trac.wordpress.org/ticket/51228 and https://core.trac.wordpress.org/changeset/57524.

WP 6.8 added polyfills for:
  * `array_find()`, `array_find_key()`, `array_any()` and `array_all()`, which were introduced in PHP 8.4. See https://core.trac.wordpress.org/ticket/62558 and https://core.trac.wordpress.org/changeset/59783.

WP 6.9 added polyfills for:
  * `array_first()` and `array_last()`, which were introduced in PHP 8.5. See https://core.trac.wordpress.org/ticket/63853 and https://core.trac.wordpress.org/changeset/60672.
  * `IMAGETYPE_HEIF` constant, which was introduced in PHP 8.5. See https://core.trac.wordpress.org/ticket/64322 and https://core.trac.wordpress.org/changeset/61328.

Note: The `IMAGETYPE_AVIF` and `IMAGETYPE_HEIF` constants are not yet flagged by PHPCompatibility. Since excluding error codes that don't exist yet doesn't trigger errors in PHPCS, we may as well add the exclusions proactively. Unless I'm missing something, I believe PHPCompatibility should be updated to check for these constants. I can prepare a PR for PHPCompatibility to start checking for those constants if that helps.

Note: WP 6.9 also added polyfills for `utf8_encode()` and `utf8_decode()`, which were deprecated in PHP 8.2 and will be removed in PHP 9.0. These are intentionally not excluded here, as these functions are deprecated and developers should migrate to `mb_convert_encoding()`. My understanding is that the WordPress polyfill exists for backward compatibility with legacy code, but PHPCompatibility should still warn about their usage.

Previous PR updating the list of polyfills: https://github.com/PHPCompatibility/PHPCompatibilityWP/pull/55