### PR TITLE
WP 7.0: account for the raised minimum PHP version and removed polyfills

### DIFF
--- a/PHPCompatibilityWP/ruleset.xml
+++ b/PHPCompatibilityWP/ruleset.xml
@@ -8,8 +8,9 @@
     As of WP 5.2, the new minimum PHP requirement is PHP 5.6.20.
     As of WP 6.3, the new minimum PHP requirement is PHP 7.0.0.
     As of WP 6.6, the new minimum PHP requirement is PHP 7.2.24.
+    As of WP 7.0, the new minimum PHP requirement is PHP 7.4.0.
     Add the following in your project PHP_CodeSniffer ruleset to enforce this:
-    <config name="testVersion" value="7.2-"/>
+    <config name="testVersion" value="7.4-"/>
 
     This directive is not included in this ruleset as individual projects may use
     a different (higher) minimum PHP version.
@@ -28,10 +29,10 @@
         * JsonSerializable: since WP 4.4.0 and removed since WP 5.3.0.
         * array_replace_recursive(): since WP 4.5.3 up to 5.2.x. The polyfill was removed in WP 5.3.
         * is_iterable(): since WP 4.9.6 and removed since WP 6.6.0.
-        * is_countable(): since WP 4.9.6
+        * is_countable(): since WP 4.9.6 and removed since WP 7.0.0.
         * IMAGETYPE_WEBP and IMG_WEBP: since WP 5.8.0 and removed since WP 6.6.0.
-        * array_key_first(): since WP 5.9.0
-        * array_key_last(): since WP 5.9.0
+        * array_key_first(): since WP 5.9.0 and removed since WP 7.0.0.
+        * array_key_last(): since WP 5.9.0 and removed since WP 7.0.0.
         * str_contains(): since WP 5.9.0
         * str_starts_with(): since WP 5.9.0
         * str_ends_with(): since WP 5.9.0

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ The WordPress minimum PHP requirement was 5.2.4 up to WP 5.1.
 * As of WP 5.2, the new minimum PHP requirement is PHP 5.6.20.
 * As of WP 6.3, the new minimum PHP requirement is PHP 7.0.0.
 * As of WP 6.6, the new minimum PHP requirement is PHP 7.2.24.
+* As of WP 7.0, the new minimum PHP requirement is PHP 7.4.0.
 
-To enforce for PHPCompatibility to run against the PHP version you want to support, add `--runtime-set testVersion 7.2-` to your command-line command or add `<config name="testVersion" value="7.2-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset), replacing `7.2-` with a `testVersion` of your choice.
+To enforce for PHPCompatibility to run against the PHP version you want to support, add `--runtime-set testVersion 7.4-` to your command-line command or add `<config name="testVersion" value="7.4-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset), replacing `7.4-` with a `testVersion` of your choice.
 
 For example:
 ```bash


### PR DESCRIPTION
WordPress 7.0 raised the minimum supported PHP version from 7.2.24 to 7.4 and, as a result, removed three polyfills from `src/wp-includes/compat.php` (`is_countable()`, `array_key_first()` and `array_key_last()`). They were introduced in PHP 7.3 and are now natively available given the new PHP 7.4 minimum. See https://core.trac.wordpress.org/ticket/62622 and https://core.trac.wordpress.org/changeset/61459.

The `<exclude>` rules for these polyfills are kept so that projects targeting older WordPress versions (where the polyfills are still present) don't get false positives. Following the existing pattern, their comments in the ruleset are updated to note that they were removed in WP 7.0.

The documented minimum PHP version and the `testVersion` example in the ruleset and the `README.md` are also updated to reflect the new PHP 7.4 requirement.

I also checked that WP 7.0 did not add any new polyfill that I could find.

Previous PR updating the list of polyfills: https://github.com/PHPCompatibility/PHPCompatibilityWP/pull/88
